### PR TITLE
Install from backports on Debian Bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ None.
 
 ## Dependencies ##
 
-None.
+- [cisagov/ansible-role-backports](https://github.com/cisagov/ansible-role-backports)
 
 ## Example Playbook ##
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -38,4 +38,6 @@ galaxy_info:
         - jammy
   role_name: nmap
 
-dependencies: []
+dependencies:
+  - name: backports
+    src: https://github.com/cisagov/ansible-role-backports

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,5 @@
 ---
+- src: https://github.com/cisagov/ansible-role-backports
+  name: backports
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,3 +16,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_packages(host, pkg):
     """Test that the appropriate packages were installed."""
     assert host.package(pkg).is_installed
+    # Verify that the version from bullseye-backports is installed
+    if (
+        host.system_info.distribution == "debian"
+        and host.system_info.codename == "bullseye"
+    ):
+        assert host.package(pkg).version.startswith("7.92")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
 # tasks file for nmap
 
-- name: Install nmap
+- name: Install nmap (Debian Bullseye)
+  ansible.builtin.apt:
+    default_release: "{{ ansible_distribution_release }}-backports"
+    name: nmap
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_distribution_release == "bullseye"
+
+- name: Install nmap (not Debian Bullseye)
   package:
     name: nmap
+  when: not (ansible_distribution == "Debian" and ansible_distribution_release == "bullseye")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,6 @@
     - ansible_distribution_release == "bullseye"
 
 - name: Install nmap (not Debian Bullseye)
-  package:
+  ansible.builtin.package:
     name: nmap
   when: not (ansible_distribution == "Debian" and ansible_distribution_release == "bullseye")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates this role to install `nmap` from [Debian Backports] on Debian Bullseye.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

There is uncertainty around the whether or not Nmap releases under the newer versions of the [Nmap Public Source License (NPSL)](https://nmap.org/npsl/) are free (as in freedom) software per https://github.com/nmap/nmap/issues/2199 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=972216. Also see the following [package changelog](https://metadata.ftp-master.debian.org/changelogs//main/n/nmap/nmap_7.91+dfsg1+really7.80+dfsg1-2_changelog) entry:

```
nmap (7.91+dfsg1+really7.80+dfsg1-1) unstable; urgency=medium

  * New upstream version 7.91+dfsg1+really7.80+dfsg1
    - Rolling back to 7.80 as the latest version has a license issue which
      most likely makes nmap not compatible with the DFSG. There are still
      discussions ongoing and upstream is deciding on what to do, meanwhile
      we are rolling back to the previous release as we are getting close
      to bullseye becoming stable. More info at the bug this is closing or
      at upstream discussion on github:
      https://github.com/nmap/nmap/issues/2199
      (closes: #972216)
  * Bump Standards-Version to 4.5.1
  * Revert "Update patches; add patch to fix automake breakage" due
    to the rollback
```

This has resulted in the `nmap` package regularly available being bumped back to version 7.80 per the above. In response to this Nmap offered versions 7.90, 7.91, and 7.92 under the "old model" for distributions per https://github.com/nmap/nmap/issues/2199#issuecomment-1272582116. As a result the version available from [bullseye-backports](https://packages.debian.org/bullseye-backports/nmap) was updated per this [changelog](https://metadata.ftp-master.debian.org/changelogs//main/n/nmap/nmap_7.92+dfsg2-1~bpo11+1_changelog) entry:

```
nmap (7.92+dfsg2-1) unstable; urgency=medium

  [ Samuel Henrique ]
  * New upstream version 7.92+dfsg2-1 (closes: #995340)
    This is the last release that can still use the previous DFSG-compatible
    license. We haven't decided yet what to do with the next ones but it might
    take a bit for them to be packaged.
  * d/copyright: Add missing libssh2 to Files-Excluded
  * d/patches:
    - Refresh patches
    - 0004-Python3-port-of-ndiff.patch: Update patch
    - update-mac-prefixes.patch: Drop patch, unneeded
```

Since the current normal release is _actually_ 7.80 (released [2019-08-10](https://nmap.org/changelog.html#7.80)) and the latest version available from [Debian Backports] is 7.92 (released [2021-08-07](https://nmap.org/changelog.html#7.92)) I believe there is value in installing from [Debian Backports] for this package.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

[Debian Backports]: https://backports.debian.org/