### PR TITLE
Update nmap package version in test

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,4 +21,4 @@ def test_packages(host, pkg):
         host.system_info.distribution == "debian"
         and host.system_info.codename == "bullseye"
     ):
-        assert host.package(pkg).version.startswith("7.92")
+        assert host.package(pkg).version.startswith("7.93")


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the `nmap` package version used in a Molecule test.

## 💭 Motivation and context ##

The version in Bullseye backports [is now 7.93](https://packages.debian.org/search?suite=bullseye-backports&searchon=names&keywords=nmap), and this was [causing the APB build to fail](https://github.com/cisagov/ansible-role-nmap/actions/runs/4002045564/jobs/6868900450).

## 🧪 Testing ##

All automated tests pass; they did not without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.